### PR TITLE
feat(ci): add deploy workflow and CHANGELOG for v2.3.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    environment: crates.io
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update 1.76.0 && rustup default 1.76.0
+      - name: Run tests
+        run: cargo test --verbose
+        env:
+          RUSTFLAGS: "-Dwarnings"
+      - name: Publish
+        run: cargo publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,8 @@ fiber-sphinx/
 │   └── CONTRIBUTING.md # Contribution guidelines
 └── .github/workflows/
     ├── ci.yml          # CI workflow (build, test, clippy)
-    └── cov.yml         # Coverage workflow
+    ├── cov.yml         # Coverage workflow
+    └── deploy.yml      # Deploy to crates.io on tag push
 ```
 
 ## CI Requirements
@@ -134,6 +135,21 @@ The CI runs on Rust 1.76.0, stable, beta, and nightly. All must pass:
 - `cargo build` - Compilation with no errors
 - `cargo test` - All tests pass
 - `cargo clippy` - No warnings (with `-Dwarnings`)
+
+## Releasing
+
+To publish a new version to crates.io:
+
+1. Update the version in `Cargo.toml`
+2. Commit the version bump
+3. Create and push a tag: `git tag v<version> && git push origin v<version>`
+4. The deploy workflow will automatically publish to crates.io
+
+**Setup:** Uses crates.io Trusted Publishers (no API token required). Configure the trusted
+publisher at https://crates.io/crates/fiber-sphinx/settings with:
+- Repository: `cryptape/fiber-sphinx`
+- Workflow: `deploy.yml`
+- Environment: `crates.io`
 
 ## Contributing Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,11 +141,29 @@ The CI runs on Rust 1.76.0, stable, beta, and nightly. All must pass:
 To publish a new version to crates.io:
 
 1. Update the version in `Cargo.toml`
-2. Commit the version bump
-3. Create and push a tag: `git tag v<version> && git push origin v<version>`
-4. The deploy workflow will automatically publish to crates.io
+2. Update `CHANGELOG.md`:
+   - Move items from `[Unreleased]` to new version section
+   - Add release date in format `YYYY-MM-DD`
+   - Add comparison link at bottom of file
+   - Update `[Unreleased]` link to compare against new version
+3. Commit the version bump
+4. Create and push a tag: `git tag v<version> && git push origin v<version>`
+5. The deploy workflow will automatically publish to crates.io
 
-**Setup:** Uses crates.io Trusted Publishers (no API token required). Configure the trusted
+### CHANGELOG Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+- **Added** for new features
+- **Changed** for changes in existing functionality
+- **Deprecated** for soon-to-be removed features
+- **Removed** for now removed features
+- **Fixed** for bug fixes
+- **Security** for vulnerability fixes
+- **Documentation** for doc-only changes
+
+### Trusted Publisher Setup
+
+Uses crates.io Trusted Publishers (no API token required). Configure the trusted
 publisher at https://crates.io/crates/fiber-sphinx/settings with:
 - Repository: `cryptape/fiber-sphinx`
 - Workflow: `deploy.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-02-02
+
 ### Added
 - Deploy workflow for automatic crates.io publishing on tag push
+- CHANGELOG.md documenting all releases
 
 ### Changed
 - Refactored code according to clippy warnings
 - Added clippy to CI pipeline
+- Added coverage workflow
 - Moved tests into a separate file
 
 ### Documentation
@@ -76,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hop shared secret derivation
 - Filler generation for packet construction
 
-[Unreleased]: https://github.com/cryptape/fiber-sphinx/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/cryptape/fiber-sphinx/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/cryptape/fiber-sphinx/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/cryptape/fiber-sphinx/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/cryptape/fiber-sphinx/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/cryptape/fiber-sphinx/compare/v1.0.1...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Deploy workflow for automatic crates.io publishing on tag push
+
+### Changed
+- Refactored code according to clippy warnings
+- Added clippy to CI pipeline
+- Moved tests into a separate file
+
+### Documentation
+- Added test vectors in spec
+
+## [2.2.0] - 2024-12-12
+
+### Added
+- `extract_public_key_from_slice` function to extract public key from bytes
+
+## [2.1.0] - 2024-11-29
+
+### Added
+- New interface to concat and split error packets
+
+## [2.0.0] - 2024-11-28
+
+### Changed
+- **Breaking:** Error parsing now returns hops index
+
+## [1.0.1] - 2024-09-29
+
+### Fixed
+- Outdated docs for error packet example
+
+### Changed
+- Enabled CI for merge group
+
+### Documentation
+- Fixed spec grammar errors
+
+## [1.0.0] - 2024-09-26
+
+### Added
+- `OnionPacket::from_bytes` to construct onion packet from bytes
+
+## [0.2.0] - 2024-09-25
+
+### Added
+- Support for returning error packets
+- Fiber Sphinx protocol specification
+
+### Documentation
+- Documented returned value of `peel`
+- Added spec on error packet
+- Linked code to the spec
+
+## [0.1.1] - 2024-09-23
+
+### Fixed
+- Crate publishing configuration
+
+## [0.1.0] - 2024-09-23
+
+### Added
+- Initial implementation of Sphinx mix network protocol
+- Onion packet creation with arbitrary packet data length
+- Onion packet peeling (decryption for next hop)
+- HMAC verification for packet integrity
+- Ephemeral key derivation for each hop
+- Hop shared secret derivation
+- Filler generation for packet construction
+
+[Unreleased]: https://github.com/cryptape/fiber-sphinx/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/cryptape/fiber-sphinx/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/cryptape/fiber-sphinx/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/cryptape/fiber-sphinx/compare/v1.0.1...v2.0.0
+[1.0.1]: https://github.com/cryptape/fiber-sphinx/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/cryptape/fiber-sphinx/compare/v0.2.0...v1.0.0
+[0.2.0]: https://github.com/cryptape/fiber-sphinx/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/cryptape/fiber-sphinx/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/cryptape/fiber-sphinx/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically publish to crates.io on tag push
- Uses **Trusted Publishers** (OIDC) - no API token required
- Add CHANGELOG.md documenting all releases from v0.1.0 to v2.3.0
- Bump version to 2.3.0

## Changes

### `.github/workflows/deploy.yml`
- Triggers on `v*` tag pushes
- Runs tests as safety check before publishing
- Uses `environment: crates.io` with OIDC permissions

### `CHANGELOG.md`
- Full release history following [Keep a Changelog](https://keepachangelog.com/) format
- Includes comparison links for easy navigation

### `AGENTS.md`
- Documented release process and Trusted Publisher setup

## Setup Required

After merging, configure the trusted publisher at https://crates.io/crates/fiber-sphinx/settings:
- Repository: `cryptape/fiber-sphinx`
- Workflow: `deploy.yml`
- Environment: `crates.io`

## Testing

- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Workflow YAML syntax validated