### PR TITLE
fix(ci): add crates-io-auth-action for Trusted Publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,6 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    environment: crates.io
 
     permissions:
       id-token: write
@@ -21,5 +20,9 @@ jobs:
         run: cargo test --verbose
         env:
           RUSTFLAGS: "-Dwarnings"
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish
         run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,10 +164,11 @@ Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
 ### Trusted Publisher Setup
 
 Uses crates.io Trusted Publishers (no API token required). Configure the trusted
-publisher at https://crates.io/crates/fiber-sphinx/settings with:
-- Repository: `cryptape/fiber-sphinx`
-- Workflow: `deploy.yml`
-- Environment: `crates.io`
+publisher at https://crates.io/crates/fiber-sphinx/settings → Trusted Publishing:
+- Repository owner: `cryptape`
+- Repository name: `fiber-sphinx`
+- Workflow filename: `deploy.yml`
+- Environment: (leave empty)
 
 ## Contributing Workflow
 


### PR DESCRIPTION
## Summary

Fixes the deploy workflow that was failing with "no token found" error.

The workflow was missing the `rust-lang/crates-io-auth-action` step which exchanges the GitHub OIDC token for a crates.io publish token.

## Changes

- Add `rust-lang/crates-io-auth-action@v1` step to exchange OIDC token
- Pass the token via `CARGO_REGISTRY_TOKEN` env var to `cargo publish`
- Remove `environment: crates.io` (not required for Trusted Publishing)
- Update AGENTS.md with correct Trusted Publisher setup instructions

## Setup Required

Configure the trusted publisher at https://crates.io/crates/fiber-sphinx/settings → Trusted Publishing:
- Repository owner: `cryptape`
- Repository name: `fiber-sphinx`
- Workflow filename: `deploy.yml`
- Environment: (leave empty)

## References

- [crates.io Trusted Publishing docs](https://crates.io/docs/trusted-publishing)
- [rust-lang/crates-io-auth-action](https://github.com/rust-lang/crates-io-auth-action)